### PR TITLE
Move env_logger to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 ress = "0.7.1"
 resast = "0.3.0"
 log = "0.4"
-env_logger = "0.6"
 backtrace = "0"
 reqwest = { version = "0.9", optional = true}
 flate2 = { version = "1", optional = true}
@@ -35,6 +34,7 @@ serde_derive = "1"
 serde = "1"
 lazy_static = "1"
 criterion = "0.2"
+env_logger = "0.6"
 
 [[bench]]
 name = "major_libs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,6 @@ extern crate ress;
 #[macro_use]
 extern crate log;
 extern crate backtrace;
-extern crate env_logger;
 
 use ress::prelude::*;
 pub use ress::Span;


### PR DESCRIPTION
It's actually the biggest non-optional dependency, but doesn't appear to
be used by the RESSA library. RESSA only needs `log`.